### PR TITLE
feat: add user systemd service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Here is an example configuration:
     "route": "chain2"
   },
   {
+    "comment": "Route *.corp.local through chain2",
+    "rules": {
+      "rule": "regexp",
+      "variable": "host",
+      "content": "(?i)^(.*\\.)?corp\\.local$"
+    },
+    "route": "chain2"
+  },
+  {
     "comment": "Route web traffic towards 10.35.0.0/16 through chain1",
     "rules": {
       "rule1": {

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,12 @@
+Simple user systemd service that automatically reloads the bbs server if the configuration is modified.
+The service units must be placed in `$HOME/.config/systemd/user/` and the bbs configuration files have to be placed in `$HOME/.config/bbs/`.
+
+```bash
+mkdir -p ~/.config/bbs/logs/ # create configuration tree
+vim -p ~/.config/bbs/{bbs.json,routes.json} # create configuration files
+mkdir -p ~/.config/systemd/user/
+loginctl enable-linger # make user systemd services persistent across logons
+systemctl --user enable --now bbs.service # bbs server
+systemctl --user enable --now bbs-watcher.service # bbs-watcher
+systemctl --user enable --now bbs-watcher.path # bbs-watcher trigger
+```

--- a/systemd/bbs-watcher.path
+++ b/systemd/bbs-watcher.path
@@ -1,0 +1,5 @@
+[Path]
+PathModified=%h/.config/bbs
+
+[Install]
+WantedBy=default.target

--- a/systemd/bbs-watcher.service
+++ b/systemd/bbs-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=bbs restarter
+
+[Service]
+Type=oneshot
+ExecStart=systemctl --user reload bbs.service
+
+[Install]
+WantedBy=default.target

--- a/systemd/bbs.service
+++ b/systemd/bbs.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=bbs
+
+[Service]
+WorkingDirectory=%h/.config/bbs/
+ExecStart=%h/go/bin/bbs -audit-file logs/bbs.log -log-file logs/log.log -log-both
+ExecReload=kill -HUP $MAINPID
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Added a user systemd system unit to automatically reload the bbs proxy whenever the configuration is modified. Also added a handy regex in the `routes.json` example.